### PR TITLE
chore: swap deprecated actions/upload-release-assets to shogo82148/actions-upload-release-asset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           tar -czvf "$ZIP_FILE_NAME" "$ARTIFACT"
 
       - name: Upload Binary Artifact
-        uses: actions/upload-release-asset@v1
+        uses: shogo82148/actions-upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
GitHub's actions/upload-release-assets is no longer maintained and seems to repeatedly break (e.g. SSLV3_ALERT_BAD_RECORD_MAC), so I suggest moving to a highly active and up to date runner.